### PR TITLE
Fix warnings in example code snippet from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ const {Router, Route} = ReactRouter;
 const history = ReactRouter.history.useQueries(ReactRouter.history.createHistory)()
 
 Meteor.startup(function() {
-  React.render((
+  const root = document.createElement('div');
+  root.setAttribute('id', 'root');
+  document.body.appendChild(root);
+  
+  ReactDOM.render((
     <Router history={history}>
       <Route path="/" component={App}>
         <Route path="/" component={HomePage} />
@@ -40,7 +44,7 @@ Meteor.startup(function() {
         {/* ... */}
       </Route>
     </Router>
-  ), document.body);
+  ), root);
 });
 ```
 


### PR DESCRIPTION
Fix example code snippet in README to remove the following React warnings

 - Warning: React.render is deprecated. Please use ReactDOM.render from require('react-dom') instead.

 - Warning: render(): Rendering components directly into document.body is discouraged, since its children are often manipulated by third-party scripts and browser extensions. This may lead to subtle reconciliation issues. Try rendering into a container element created for your app.